### PR TITLE
fix: correctly display markdown in opportunity and event pages

### DIFF
--- a/app/companies/[slug]/page.module.scss
+++ b/app/companies/[slug]/page.module.scss
@@ -78,29 +78,6 @@
   display: none;
 }
 
-.markdownContainer {
-  list-style-position: inside;
-  table {
-    width: 100%;
-    border-collapse: collapse;
-    margin: 1em 0;
-  }
-  table,
-  th,
-  td {
-    border: 1px solid;
-    border-color: var(--gray-6);
-    padding: 0.25em;
-  }
-  th {
-    text-align: left;
-  }
-  code {
-    background-color: var(--gray-4);
-    padding: 0.3em;
-  }
-}
-
 .opportunityPanel {
   margin-top: 2em;
 }

--- a/app/companies/[slug]/page.tsx
+++ b/app/companies/[slug]/page.tsx
@@ -3,6 +3,7 @@ import OpportunityTable from "@/app/opportunities/OpportunityTable"
 import { auth } from "@/auth"
 import { EditCompany } from "@/components/EditCompany"
 import Link from "@/components/Link"
+import MdViewer from "@/components/MdViewer"
 import { AddOpportunity } from "@/components/UpsertOpportunity"
 import RestrictedAreaCompany, { checkCompany } from "@/components/rbac/RestrictedAreaCompany"
 import prisma from "@/lib/db"
@@ -17,10 +18,6 @@ import Image from "next/image"
 import { notFound } from "next/navigation"
 import React from "react"
 import { BsBuildings, BsEnvelope, BsGlobe, BsTelephone } from "react-icons/bs"
-import Markdown from "react-markdown"
-import rehypeRaw from "rehype-raw"
-import remarkBreaks from "remark-breaks"
-import remarkGfm from "remark-gfm"
 
 /**
  * Conditional rendering of company detail. Will only render if children are truthy.
@@ -161,15 +158,7 @@ const CompanyPage = async ({ params }: { params: { slug: string } }) => {
               <Collapsible.Root className={styles.CollapsibleRoot}>
                 <Box className={styles.summaryContainer}>
                   <CompanyDetail title="Summary">
-                    {companyProfile.summary && (
-                      <Markdown
-                        className={styles.markdownContainer}
-                        remarkPlugins={[remarkGfm, remarkBreaks]}
-                        rehypePlugins={[rehypeRaw]}
-                      >
-                        {companyProfile.summary}
-                      </Markdown>
-                    )}
+                    {companyProfile.summary && <MdViewer markdown={companyProfile.summary} />}
                   </CompanyDetail>
 
                   <CompanyDetail title="Website">

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { getCompanyLink } from "@/app/companies/getCompanyLink"
 import Link from "@/components/Link"
+import MdViewer from "@/components/MdViewer"
 import prisma from "@/lib/db"
 
 import styles from "./page.module.scss"
@@ -10,7 +11,6 @@ import Image from "next/image"
 import { notFound } from "next/navigation"
 import React from "react"
 import { BsBoxArrowUpRight, BsCalendar, BsPinMap } from "react-icons/bs"
-import Markdown from "react-markdown"
 
 /**
  * Format an event's date to JSX
@@ -152,8 +152,7 @@ const EventPage = async ({ params }: { params: { id: string } }) => {
 
         <Flex gap="2" direction="column">
           <Heading>About</Heading>
-
-          <Markdown>{event.richSummary}</Markdown>
+          <MdViewer markdown={event.richSummary} />
         </Flex>
       </Card>
     </Flex>

--- a/app/opportunities/[id]/page.tsx
+++ b/app/opportunities/[id]/page.tsx
@@ -2,6 +2,7 @@ import { getCompanyLink } from "@/app/companies/getCompanyLink"
 import Chip from "@/components/Chip"
 import { DeleteOpportunity } from "@/components/DeleteOpportunity"
 import Link from "@/components/Link"
+import MdViewer from "@/components/MdViewer"
 import { EditOpportunity } from "@/components/UpsertOpportunity"
 import RestrictedAreaCompany from "@/components/rbac/RestrictedAreaCompany"
 import prisma from "@/lib/db"
@@ -14,7 +15,6 @@ import Image from "next/image"
 import { notFound } from "next/navigation"
 import React from "react"
 import { BsBoxArrowUpRight, BsBriefcase, BsCalendar, BsCheckCircle, BsPinMap, BsXCircle } from "react-icons/bs"
-import Markdown from "react-markdown"
 
 const OpportunityPage = async ({ params }: { params: { id: string } }) => {
   const id = parseInt(params.id, 10)
@@ -88,7 +88,7 @@ const OpportunityPage = async ({ params }: { params: { id: string } }) => {
         <Flex direction="column" gap="3">
           <Flex direction="column" gap="2">
             <Heading>Full Opportunity Description</Heading>
-            <Markdown>{opportunity.description}</Markdown>
+            <MdViewer markdown={opportunity.description} />
           </Flex>
 
           <Flex direction="column" gap="2">

--- a/components/MdViewer.tsx
+++ b/components/MdViewer.tsx
@@ -1,0 +1,17 @@
+import styles from "./md-viewer.module.scss"
+
+import React from "react"
+import Markdown from "react-markdown"
+import rehypeRaw from "rehype-raw"
+import remarkBreaks from "remark-breaks"
+import remarkGfm from "remark-gfm"
+
+const MdViewer = ({ markdown }: { markdown: string }) => {
+  return (
+    <Markdown className={styles.markdownViewer} remarkPlugins={[remarkGfm, remarkBreaks]} rehypePlugins={[rehypeRaw]}>
+      {markdown}
+    </Markdown>
+  )
+}
+
+export default MdViewer

--- a/components/md-viewer.module.scss
+++ b/components/md-viewer.module.scss
@@ -1,0 +1,21 @@
+.markdownViewer {
+  list-style-position: inside;
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 1em 0;
+  }
+  table,
+  th,
+  td {
+    border: 1px solid;
+    border-color: var(--gray-6);
+    padding: 0.25em;
+  }
+  th {
+    text-align: left;
+  }
+  code {
+    background-color: var(--gray-4);
+  }
+}


### PR DESCRIPTION
Markdown now displays correctly for opportunities and events:

![Screenshot 2024-08-19 at 18 58 27](https://github.com/user-attachments/assets/5b89c47e-ed31-4920-801a-4829d4be966f)
