### PR TITLE
feat: pick columns

### DIFF
--- a/app/companies/CompanyTable.tsx
+++ b/app/companies/CompanyTable.tsx
@@ -85,10 +85,10 @@ const CompanyTable = ({ companies, initialColumns, nonFilterable = [] }: Company
       }
     }
 
-    return Object.entries(columnDefsMap).map(([columnName, columnDef]) =>
-      columnHelper.accessor(columnName as ColumnName, columnDef),
-    )
-  }, [nonFilterable])
+    return Object.entries(columnDefsMap)
+      .filter(([columnName, _]) => session?.user?.role === "ADMIN" || columnName !== "slug")
+      .map(([columnName, columnDef]) => columnHelper.accessor(columnName as ColumnName, columnDef))
+  }, [nonFilterable, session?.user?.role])
 
   const invisibleColumns =
     session?.user?.role === "ADMIN"

--- a/app/companies/[slug]/page.tsx
+++ b/app/companies/[slug]/page.tsx
@@ -220,7 +220,7 @@ const CompanyPage = async ({ params }: { params: { slug: string } }) => {
             <Box p="8">
               <EventTable
                 events={companyProfile.events}
-                columns={["title", "dateStart", "shortDescription", "location", "spaces"]}
+                initialColumns={["title", "dateStart", "shortDescription", "location", "spaces"]}
                 displayColumns={
                   !!session && (session.user.role === Role.ADMIN || (await checkCompany(companyProfile.id)(session)))
                     ? ["adminButtons"]

--- a/app/companies/[slug]/page.tsx
+++ b/app/companies/[slug]/page.tsx
@@ -197,7 +197,7 @@ const CompanyPage = async ({ params }: { params: { slug: string } }) => {
             <Box p="8">
               <OpportunityTable
                 opportunities={companyProfile.opportunities}
-                columns={["position", "location", "type", "createdAt", "deadline"]}
+                initialColumns={["position", "location", "type", "createdAt", "deadline"]}
                 displayColumns={
                   !!session && (session.user.role === Role.ADMIN || (await checkCompany(companyProfile.id)(session)))
                     ? ["adminButtons"]

--- a/app/companies/page.tsx
+++ b/app/companies/page.tsx
@@ -24,7 +24,7 @@ const OpportunitiesPage = async () => {
       <Flex gap="5" direction="column" align="center">
         <Heading size="8">Companies</Heading>
         <CompanyAdminActions />
-        <CompanyTable columns={["name", "sector", "size", "hq"]} companies={companies} />
+        <CompanyTable initialColumns={["name", "sector", "size", "hq"]} companies={companies} />
       </Flex>
     </RestrictedArea>
   )

--- a/app/events/EventTable.tsx
+++ b/app/events/EventTable.tsx
@@ -25,19 +25,16 @@ type DisplayColumnName = "adminButtons"
 
 type ColumnName = keyof EventRow | `company.${keyof CompanyProfile}`
 
-const EventTable = ({
-  events,
-  columns,
-  displayColumns = [],
-  nonFilterable = [],
-}: {
+interface EventTableProps {
   events: EventRow[]
-  columns: ColumnName[]
+  initialColumns: ColumnName[]
   displayColumns?: DisplayColumnName[]
   nonFilterable?: ColumnName[]
-}) => {
-  const columnDefsMap = useMemo(() => {
-    const columnDefsMap_: Partial<Record<ColumnName, ColumnDef<EventRow, any>>> = {
+}
+
+const EventTable = ({ events, initialColumns, displayColumns = [], nonFilterable = [] }: EventTableProps) => {
+  const columnDefs = useMemo(() => {
+    const columnDefsMap: Partial<Record<ColumnName, ColumnDef<EventRow, any>>> = {
       "company.name": {
         cell: info => (
           <Flex align="center" justify="start" gap="4">
@@ -97,31 +94,15 @@ const EventTable = ({
     }
 
     for (let column of nonFilterable) {
-      if (columnDefsMap_[column]) {
-        columnDefsMap_[column]!.enableColumnFilter = false
+      if (columnDefsMap[column]) {
+        columnDefsMap[column]!.enableColumnFilter = false
       }
     }
 
-    return columnDefsMap_
+    return Object.entries(columnDefsMap).map(([columnName, columnDef]) =>
+      columnHelper.accessor(columnName as ColumnName, columnDef),
+    )
   }, [nonFilterable])
-
-  const columnDefs = useMemo(
-    () =>
-      columns.map((columnName: ColumnName) =>
-        columnHelper.accessor(
-          columnName,
-          columnDefsMap[columnName] ?? {
-            // default column definition, so that all company values are also accessible
-            cell: info => info.getValue(),
-            header: columnName,
-            sortingFn: "alphanumeric",
-            id: columnName,
-            enableColumnFilter: !(columnName in nonFilterable),
-          },
-        ),
-      ),
-    [columnDefsMap, columns, nonFilterable],
-  )
 
   const displayColumnDefsMap: Record<DisplayColumnName, DisplayColumnDef<EventRow, any>> = useMemo(
     () => ({
@@ -141,12 +122,27 @@ const EventTable = ({
     [],
   )
 
+  const initialColumnVisibility = useMemo(() => {
+    const initialColumnVisibility_: Partial<Record<ColumnName, boolean>> = {}
+    for (const columnDef of columnDefs) {
+      initialColumnVisibility_[columnDef.accessorKey as ColumnName] = false
+    }
+    initialColumns.forEach(column => (initialColumnVisibility_[column] = true))
+    return initialColumnVisibility_
+  }, [columnDefs, initialColumns])
+
   const displayColumnDefs = useMemo(
     () => displayColumns.map((columnName: DisplayColumnName) => columnHelper.display(displayColumnDefsMap[columnName])),
     [displayColumnDefsMap, displayColumns],
   )
 
-  return <TanstackTable data={events} columns={[...columnDefs, ...displayColumnDefs]} />
+  return (
+    <TanstackTable
+      data={events}
+      columns={[...columnDefs, ...displayColumnDefs]}
+      initialColumnVisibility={initialColumnVisibility}
+    />
+  )
 }
 
 export default EventTable

--- a/app/events/EventTable.tsx
+++ b/app/events/EventTable.tsx
@@ -113,7 +113,7 @@ const EventTable = ({ events, initialColumns, displayColumns = [], nonFilterable
             <DeleteEvent id={info.row.original.id} companyID={info.row.original.companyID} />
           </Flex>
         ),
-        header: "",
+        header: "Admin Actions",
         id: "adminButtons",
         enableSorting: false,
         enableColumnFilter: false,

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -20,7 +20,7 @@ const EventsPage = async () => {
         <Heading size="8">Events</Heading>
         <EventTable
           events={events}
-          columns={["company.name", "title", "dateStart", "shortDescription", "location", "spaces"]}
+          initialColumns={["company.name", "title", "dateStart", "shortDescription", "location", "spaces"]}
         />
       </Flex>
     </RestrictedArea>

--- a/app/opportunities/OpportunityTable.tsx
+++ b/app/opportunities/OpportunityTable.tsx
@@ -120,7 +120,7 @@ const OpportunityTable = ({
             <DeleteOpportunity id={info.row.original.id} companyID={info.row.original.companyID} />
           </Flex>
         ),
-        header: "",
+        header: "Admin Actions",
         id: "adminButtons",
         enableSorting: false,
         enableColumnFilter: false,

--- a/app/opportunities/page.tsx
+++ b/app/opportunities/page.tsx
@@ -19,7 +19,7 @@ const OpportunitiesPage = async () => {
         <Heading size="8">Opportunities</Heading>
         <OpportunityTable
           opportunities={opportunities}
-          columns={["company.name", "position", "location", "type", "createdAt", "deadline"]}
+          initialColumns={["company.name", "position", "location", "type", "createdAt", "deadline"]}
         />
       </Flex>
     </RestrictedArea>

--- a/app/students/StudentTable.tsx
+++ b/app/students/StudentTable.tsx
@@ -125,7 +125,7 @@ const StudentTable = ({
     [columnDefsMap, columns, nonFilterable],
   )
 
-  return <TanstackTable data={students} columns={columnDefs} />
+  return <TanstackTable data={students} columns={columnDefs} initialColumnVisibility={{ name: false }} />
 }
 
 export default StudentTable

--- a/app/students/StudentTable.tsx
+++ b/app/students/StudentTable.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import Link from "@/components/Link"
-import TanstackTable, { dateFilterFn } from "@/components/TanstackTable"
+import TanstackTable, { arrayFilterFn, dateFilterFn } from "@/components/TanstackTable"
 import UserAvatar from "@/components/UserAvatar"
 
 import { StudentProfile, User } from "@prisma/client"
@@ -74,14 +74,14 @@ const StudentTable = ({
         header: "Skills",
         id: "skills",
         enableSorting: false,
-        filterFn: "arrIncludes",
+        filterFn: arrayFilterFn,
       },
       interests: {
         cell: info => info.getValue().join(", "),
         header: "Interests",
         id: "interests",
         enableSorting: false,
-        filterFn: "arrIncludes",
+        filterFn: arrayFilterFn,
       },
     }
 

--- a/app/students/StudentTable.tsx
+++ b/app/students/StudentTable.tsx
@@ -12,7 +12,10 @@ import { useMemo } from "react"
 
 type StudentRow = {
   user: Pick<User, "name" | "updatedAt" | "image" | "role">
-} & Pick<StudentProfile, "interests" | "skills" | "lookingFor" | "graduationDate" | "course" | "studentShortcode">
+} & Pick<
+  StudentProfile,
+  "updatedAt" | "interests" | "skills" | "lookingFor" | "graduationDate" | "course" | "studentShortcode"
+>
 
 const columnHelper = createColumnHelper<StudentRow>()
 
@@ -82,6 +85,17 @@ const StudentTable = ({
         id: "interests",
         enableSorting: false,
         filterFn: arrayFilterFn,
+      },
+      updatedAt: {
+        cell: info => (
+          <time suppressHydrationWarning={true}>
+            {formatDistanceToNowStrict(info.getValue(), { addSuffix: true })}{" "}
+          </time>
+        ),
+        header: "Updated",
+        id: "updatedAt",
+        sortingFn: "datetime",
+        enableColumnFilter: false,
       },
     }
 

--- a/app/students/StudentTable.tsx
+++ b/app/students/StudentTable.tsx
@@ -12,7 +12,7 @@ import { useMemo } from "react"
 
 type StudentRow = {
   user: Pick<User, "name" | "updatedAt" | "image" | "role">
-} & Pick<StudentProfile, "graduationDate" | "course" | "studentShortcode">
+} & Pick<StudentProfile, "interests" | "skills" | "lookingFor" | "graduationDate" | "course" | "studentShortcode">
 
 const columnHelper = createColumnHelper<StudentRow>()
 
@@ -62,6 +62,26 @@ const StudentTable = ({
         header: "Last Updated",
         id: "updatedAt",
         sortingFn: "datetime",
+      },
+      lookingFor: {
+        cell: info => info.getValue(),
+        header: "Looking For",
+        id: "lookingFor",
+        sortingFn: "text",
+      },
+      skills: {
+        cell: info => info.getValue().join(", "),
+        header: "Skills",
+        id: "skills",
+        enableSorting: false,
+        filterFn: "arrIncludes",
+      },
+      interests: {
+        cell: info => info.getValue().join(", "),
+        header: "Interests",
+        id: "interests",
+        enableSorting: false,
+        filterFn: "arrIncludes",
       },
     }
 

--- a/app/students/page.tsx
+++ b/app/students/page.tsx
@@ -18,12 +18,18 @@ const StudentsPage = async () => {
       graduationDate: true,
       course: true,
       studentShortcode: true,
+      lookingFor: true,
+      skills: true,
+      interests: true,
     },
   })
   return (
     <Flex direction="column" gap="5" align="center" width="100%">
       <Heading size="8">Students</Heading>
-      <StudentTable students={students} columns={["user.name", "course", "graduationDate", "user.updatedAt"]} />
+      <StudentTable
+        students={students}
+        columns={["user.name", "course", "graduationDate", "lookingFor", "skills", "interests", "user.updatedAt"]}
+      />
     </Flex>
   )
 }

--- a/app/students/page.tsx
+++ b/app/students/page.tsx
@@ -10,7 +10,6 @@ const StudentsPage = async () => {
       user: {
         select: {
           name: true,
-          updatedAt: true,
           image: true,
           role: true,
         },
@@ -29,7 +28,7 @@ const StudentsPage = async () => {
       <Heading size="8">Students</Heading>
       <StudentTable
         students={students}
-        columns={["user.name", "course", "graduationDate", "lookingFor", "skills", "interests", "updatedAt"]}
+        initialColumns={["user.name", "interests", "skills", "updatedAt", "graduationDate"]}
       />
     </Flex>
   )

--- a/app/students/page.tsx
+++ b/app/students/page.tsx
@@ -21,6 +21,7 @@ const StudentsPage = async () => {
       lookingFor: true,
       skills: true,
       interests: true,
+      updatedAt: true,
     },
   })
   return (
@@ -28,7 +29,7 @@ const StudentsPage = async () => {
       <Heading size="8">Students</Heading>
       <StudentTable
         students={students}
-        columns={["user.name", "course", "graduationDate", "lookingFor", "skills", "interests", "user.updatedAt"]}
+        columns={["user.name", "course", "graduationDate", "lookingFor", "skills", "interests", "updatedAt"]}
       />
     </Flex>
   )

--- a/components/TanstackTable.tsx
+++ b/components/TanstackTable.tsx
@@ -74,6 +74,20 @@ export const dateFilterFn = <T,>(row: Row<T>, id: string, filterValue: [string, 
   (!filterValue[0] || isAfter(row.getValue(id), filterValue[0] + "T00:00")) &&
   (!filterValue[1] || isAfter(filterValue[1] + "T23:59", row.getValue(id)))
 
+/**
+ * Filter function for columns with type array. Keeps rows where the cell of column "id" includes the filterValue.
+ * @template T The type of the row
+ * @param row The row to filter
+ * @param id The column id to filter
+ * @param filterValue The keyword to look for in the array
+ * @returns Whether the row should be displayed
+ */
+export const arrayFilterFn = <T,>(row: Row<T>, id: string, filterValue: string): boolean => {
+  const array = row.getValue(id)
+  const filterValueLower = filterValue.toLowerCase()
+  return Array.isArray(array) && array.some((item: string) => item.toLowerCase().includes(filterValueLower))
+}
+
 const getSortingIcon = (isSorted: false | SortDirection): React.ReactNode => {
   switch (isSorted) {
     case false:
@@ -186,7 +200,7 @@ export default function TanstackTable<T>({
     (value: any) => {
       const newFilters = [
         ...columnFilters.filter(f => f.id !== currentFilteredColumn), // Remove the previous filter for the same column
-        { id: currentFilteredColumn, value }, // Add the new filter for this column
+        ...(value ? [{ id: currentFilteredColumn, value }] : []), // Add the new filter for this column if not empty
       ]
 
       // Live-update filter chips which are currently displayed (i.e. in prevFilters)

--- a/components/TanstackTable.tsx
+++ b/components/TanstackTable.tsx
@@ -253,7 +253,7 @@ export default function TanstackTable<T>({
           <Button asChild variant="surface" color="gray">
             <DropdownMenu.Trigger>
               <Text>Choose columns to display</Text>
-              <ChevronUpIcon />
+              <ChevronDownIcon />
             </DropdownMenu.Trigger>
           </Button>
           <DropdownMenu.Portal>

--- a/components/TanstackTable.tsx
+++ b/components/TanstackTable.tsx
@@ -43,6 +43,7 @@ const ICON_SIZE = 20
 interface TanstackTableProps<T> {
   data: T[]
   columns: ColumnDef<T, any>[]
+  initialColumnVisibility?: VisibilityState
   enablePagination?: boolean
   enableSearch?: boolean
   invisibleColumns?: VisibilityState
@@ -105,13 +106,14 @@ const getSortingIcon = (isSorted: false | SortDirection): React.ReactNode => {
 export default function TanstackTable<T>({
   data,
   columns,
+  initialColumnVisibility,
   invisibleColumns,
   enablePagination = true,
   enableSearch = true,
 }: TanstackTableProps<T>) {
   const [sorting, setSorting] = useState<SortingState>([])
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
-  const [columnVisibility, setColumnVisibility] = useState({})
+  const [columnVisibility, setColumnVisibility] = useState(initialColumnVisibility ?? {})
 
   const [pagination, setPagination] = useState({
     pageIndex: 0, //initial page index

--- a/components/TanstackTable.tsx
+++ b/components/TanstackTable.tsx
@@ -248,10 +248,19 @@ export default function TanstackTable<T>({
   const clearCurrentFilter = useCallback(() => {
     if (!prevFilters.find(f => f.id === currentFilteredColumn)) {
       setColumnFilters(columnFilters.filter(f => f.id !== currentFilteredColumn))
+    } else if (arrayFilterColumns.includes(currentFilteredColumn)) {
+      // remove last value in array filter
+      const value = [...(prevFilters.find(f => f.id === currentFilteredColumn)!.value as string[]).slice(0, -1), ""]
+      const newFilters = [
+        ...prevFilters.filter(f => f.id !== currentFilteredColumn), // Remove the previous filter for the same column
+        { id: currentFilteredColumn, value },
+      ]
+      setPrevFilters(newFilters)
+      setColumnFilters(newFilters)
     }
 
     setSearchQuery("")
-  }, [columnFilters, currentFilteredColumn, prevFilters])
+  }, [arrayFilterColumns, columnFilters, currentFilteredColumn, prevFilters])
 
   if (!isClient) {
     return (

--- a/components/TanstackTable.tsx
+++ b/components/TanstackTable.tsx
@@ -4,8 +4,10 @@ import Chip from "./Chip"
 import { Dropdown } from "./Dropdown"
 import styles from "./tanstack-table.module.scss"
 
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu"
 import {
   CaretSortIcon,
+  CheckIcon,
   ChevronDownIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
@@ -66,6 +68,7 @@ export default function TanstackTable<T>({
 }: TanstackTableProps<T>) {
   const [sorting, setSorting] = useState<SortingState>([])
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
+  const [columnVisibility, setColumnVisibility] = useState({})
 
   const [pagination, setPagination] = useState({
     pageIndex: 0, //initial page index
@@ -75,7 +78,8 @@ export default function TanstackTable<T>({
     data,
     columns,
     getCoreRowModel: getCoreRowModel(),
-    state: { columnFilters, sorting, pagination, columnVisibility: invisibleColumns },
+    state: { columnFilters, sorting, pagination, columnVisibility: { ...columnVisibility, ...invisibleColumns } },
+    onColumnVisibilityChange: setColumnVisibility,
     onSortingChange: setSorting,
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
@@ -193,6 +197,31 @@ export default function TanstackTable<T>({
               }}
             />
             <Button onClick={addFilter}>Add filter</Button>
+            <DropdownMenu.Root>
+              <DropdownMenu.Trigger>
+                <Button variant="soft">Columns</Button>
+              </DropdownMenu.Trigger>
+              <DropdownMenu.Portal>
+                <DropdownMenu.Content className={styles.DropdownMenuContent}>
+                  {table.getAllLeafColumns().map((column, index) => (
+                    <DropdownMenu.CheckboxItem
+                      //onSelect={(e) => e.preventDefault()}
+                      key={index}
+                      checked={column.getIsVisible()}
+                      onSelect={e => {
+                        column.getToggleVisibilityHandler()(e)
+                        e.preventDefault()
+                      }}
+                    >
+                      <DropdownMenu.ItemIndicator>
+                        <CheckIcon />
+                      </DropdownMenu.ItemIndicator>
+                      {column.id}
+                    </DropdownMenu.CheckboxItem>
+                  ))}
+                </DropdownMenu.Content>
+              </DropdownMenu.Portal>
+            </DropdownMenu.Root>
           </Flex>
           <Flex gap="2" justify="center">
             {prevFilters.map(({ id, value }, index) => (

--- a/components/TanstackTable.tsx
+++ b/components/TanstackTable.tsx
@@ -308,7 +308,7 @@ export default function TanstackTable<T>({
                 item: col.columnDef.header!.toString(),
                 value: col.columnDef.id!,
               }))}
-              defaultValue={filterableColumns[0].id ?? ""}
+              defaultValue={filterableColumns[0]?.id ?? ""}
               onValueChange={newFilterCol => {
                 clearCurrentFilter()
 

--- a/components/TanstackTable.tsx
+++ b/components/TanstackTable.tsx
@@ -143,6 +143,34 @@ export default function TanstackTable<T>({
       {enableSearch && (
         <Flex direction="column" gap="3">
           <Flex gap="3" className={styles.searchBarContainer}>
+            <DropdownMenu.Root>
+              <Button asChild variant="surface" color="gray">
+                <DropdownMenu.Trigger>
+                  Columns
+                  <ChevronDownIcon />
+                </DropdownMenu.Trigger>
+              </Button>
+              <DropdownMenu.Portal>
+                <DropdownMenu.Content className={styles.DropdownMenuContent + " radix-themes"}>
+                  {table.getAllLeafColumns().map((column, index) => (
+                    <DropdownMenu.CheckboxItem
+                      key={index}
+                      checked={column.getIsVisible()}
+                      onSelect={e => {
+                        column.getToggleVisibilityHandler()(e)
+                        e.preventDefault()
+                      }}
+                      className={styles.DropdownMenuCheckboxItem}
+                    >
+                      <DropdownMenu.ItemIndicator className={styles.DropdownMenuItemIndicator}>
+                        <CheckIcon />
+                      </DropdownMenu.ItemIndicator>
+                      <Text>{column.columnDef.header?.toString()}</Text>
+                    </DropdownMenu.CheckboxItem>
+                  ))}
+                </DropdownMenu.Content>
+              </DropdownMenu.Portal>
+            </DropdownMenu.Root>
             <TextField.Root
               placeholder={`Search by ${table.getColumn(currentFilteredColumn)?.columnDef.header?.toString() ?? "..."}`}
               className={styles.searchBar}
@@ -197,32 +225,6 @@ export default function TanstackTable<T>({
               }}
             />
             <Button onClick={addFilter}>Add filter</Button>
-            <DropdownMenu.Root>
-              <DropdownMenu.Trigger>
-                <Button variant="soft">Columns</Button>
-              </DropdownMenu.Trigger>
-              <DropdownMenu.Portal>
-                <DropdownMenu.Content className={styles.DropdownMenuContent} sideOffset={5}>
-                  {table.getAllLeafColumns().map((column, index) => (
-                    <DropdownMenu.CheckboxItem
-                      //onSelect={(e) => e.preventDefault()}
-                      key={index}
-                      checked={column.getIsVisible()}
-                      onSelect={e => {
-                        column.getToggleVisibilityHandler()(e)
-                        e.preventDefault()
-                      }}
-                      className={styles.DropdownMenuCheckboxItem}
-                    >
-                      <DropdownMenu.ItemIndicator className={styles.DropdownMenuItemIndicator}>
-                        <CheckIcon />
-                      </DropdownMenu.ItemIndicator>
-                      {column.id}
-                    </DropdownMenu.CheckboxItem>
-                  ))}
-                </DropdownMenu.Content>
-              </DropdownMenu.Portal>
-            </DropdownMenu.Root>
           </Flex>
           <Flex gap="2" justify="center">
             {prevFilters.map(({ id, value }, index) => (

--- a/components/TanstackTable.tsx
+++ b/components/TanstackTable.tsx
@@ -202,7 +202,7 @@ export default function TanstackTable<T>({
                 <Button variant="soft">Columns</Button>
               </DropdownMenu.Trigger>
               <DropdownMenu.Portal>
-                <DropdownMenu.Content className={styles.DropdownMenuContent}>
+                <DropdownMenu.Content className={styles.DropdownMenuContent} sideOffset={5}>
                   {table.getAllLeafColumns().map((column, index) => (
                     <DropdownMenu.CheckboxItem
                       //onSelect={(e) => e.preventDefault()}
@@ -212,8 +212,9 @@ export default function TanstackTable<T>({
                         column.getToggleVisibilityHandler()(e)
                         e.preventDefault()
                       }}
+                      className={styles.DropdownMenuCheckboxItem}
                     >
-                      <DropdownMenu.ItemIndicator>
+                      <DropdownMenu.ItemIndicator className={styles.DropdownMenuItemIndicator}>
                         <CheckIcon />
                       </DropdownMenu.ItemIndicator>
                       {column.id}

--- a/components/TanstackTable.tsx
+++ b/components/TanstackTable.tsx
@@ -143,34 +143,6 @@ export default function TanstackTable<T>({
       {enableSearch && (
         <Flex direction="column" gap="3">
           <Flex gap="3" className={styles.searchBarContainer}>
-            <DropdownMenu.Root>
-              <Button asChild variant="surface" color="gray">
-                <DropdownMenu.Trigger>
-                  Columns
-                  <ChevronDownIcon />
-                </DropdownMenu.Trigger>
-              </Button>
-              <DropdownMenu.Portal>
-                <DropdownMenu.Content className={styles.DropdownMenuContent + " radix-themes"}>
-                  {table.getAllLeafColumns().map((column, index) => (
-                    <DropdownMenu.CheckboxItem
-                      key={index}
-                      checked={column.getIsVisible()}
-                      onSelect={e => {
-                        column.getToggleVisibilityHandler()(e)
-                        e.preventDefault()
-                      }}
-                      className={styles.DropdownMenuCheckboxItem}
-                    >
-                      <DropdownMenu.ItemIndicator className={styles.DropdownMenuItemIndicator}>
-                        <CheckIcon />
-                      </DropdownMenu.ItemIndicator>
-                      <Text>{column.columnDef.header?.toString()}</Text>
-                    </DropdownMenu.CheckboxItem>
-                  ))}
-                </DropdownMenu.Content>
-              </DropdownMenu.Portal>
-            </DropdownMenu.Root>
             <TextField.Root
               placeholder={`Search by ${table.getColumn(currentFilteredColumn)?.columnDef.header?.toString() ?? "..."}`}
               className={styles.searchBar}
@@ -276,51 +248,81 @@ export default function TanstackTable<T>({
           ))}
         </Table.Body>
       </Table.Root>
+      <Flex justify="between">
+        <DropdownMenu.Root>
+          <Button asChild variant="surface" color="gray">
+            <DropdownMenu.Trigger>
+              <Text>Choose columns to display</Text>
+              <ChevronUpIcon />
+            </DropdownMenu.Trigger>
+          </Button>
+          <DropdownMenu.Portal>
+            <DropdownMenu.Content className={styles.DropdownMenuContent + " radix-themes"}>
+              {table.getAllLeafColumns().map((column, index) => (
+                <DropdownMenu.CheckboxItem
+                  key={index}
+                  checked={column.getIsVisible()}
+                  onSelect={e => {
+                    column.getToggleVisibilityHandler()(e)
+                    e.preventDefault()
+                  }}
+                  className={styles.DropdownMenuCheckboxItem}
+                >
+                  <DropdownMenu.ItemIndicator className={styles.DropdownMenuItemIndicator}>
+                    <CheckIcon />
+                  </DropdownMenu.ItemIndicator>
+                  <Text>{column.columnDef.header?.toString()}</Text>
+                </DropdownMenu.CheckboxItem>
+              ))}
+            </DropdownMenu.Content>
+          </DropdownMenu.Portal>
+        </DropdownMenu.Root>
 
-      {enablePagination && (
-        <Pagination
-          totalPages={table.getPageCount()}
-          middlePagesSiblingCount={isLowWidth ? 1 : 2}
-          edgePageCount={0}
-          currentPage={table.getState().pagination.pageIndex}
-          setCurrentPage={table.setPageIndex}
-          truncableText="..."
-        >
-          <nav className={styles.tablePagination}>
-            <FooterWrapper columns="3" gap="3" width="100%" direction="column" align="center">
-              <Box />
-              <ul>
-                <IconButton variant="outline" disabled={!table.getCanPreviousPage()} onClick={table.firstPage}>
-                  <DoubleArrowLeftIcon />
-                </IconButton>
-                <Pagination.PrevButton className="" as={<IconButton variant="outline" />}>
-                  <ChevronLeftIcon />
-                </Pagination.PrevButton>
-                <Pagination.PageButton
-                  as={<Button variant="outline" />}
-                  activeClassName={styles.activePage}
-                  inactiveClassName=""
-                  className=""
-                />
-                <Pagination.NextButton as={<IconButton variant="outline" />}>
-                  <ChevronRightIcon />
-                </Pagination.NextButton>
-                <IconButton variant="outline" disabled={!table.getCanNextPage()} onClick={table.lastPage}>
-                  <DoubleArrowRightIcon />
-                </IconButton>
-              </ul>
-              <Flex justify="end" gap="3">
-                <Dropdown
-                  items={["1", "5", "15", "25", "50"].map(i => ({ item: i, value: i }))}
-                  defaultValue={table.getState().pagination.pageSize.toString()}
-                  onValueChange={newPageSize => table.setPageSize(parseInt(newPageSize))}
-                />
-                <Text className={styles.inlineFlexCenter}>records per page</Text>
-              </Flex>
-            </FooterWrapper>
-          </nav>
-        </Pagination>
-      )}
+        {enablePagination && (
+          <Pagination
+            totalPages={table.getPageCount()}
+            middlePagesSiblingCount={isLowWidth ? 1 : 2}
+            edgePageCount={0}
+            currentPage={table.getState().pagination.pageIndex}
+            setCurrentPage={table.setPageIndex}
+            truncableText="..."
+          >
+            <nav className={styles.tablePagination}>
+              <FooterWrapper columns="3" gap="3" width="100%" direction="column" align="center">
+                <Box />
+                <ul>
+                  <IconButton variant="outline" disabled={!table.getCanPreviousPage()} onClick={table.firstPage}>
+                    <DoubleArrowLeftIcon />
+                  </IconButton>
+                  <Pagination.PrevButton className="" as={<IconButton variant="outline" />}>
+                    <ChevronLeftIcon />
+                  </Pagination.PrevButton>
+                  <Pagination.PageButton
+                    as={<Button variant="outline" />}
+                    activeClassName={styles.activePage}
+                    inactiveClassName=""
+                    className=""
+                  />
+                  <Pagination.NextButton as={<IconButton variant="outline" />}>
+                    <ChevronRightIcon />
+                  </Pagination.NextButton>
+                  <IconButton variant="outline" disabled={!table.getCanNextPage()} onClick={table.lastPage}>
+                    <DoubleArrowRightIcon />
+                  </IconButton>
+                </ul>
+                <Flex justify="end" gap="3">
+                  <Dropdown
+                    items={["1", "5", "15", "25", "50"].map(i => ({ item: i, value: i }))}
+                    defaultValue={table.getState().pagination.pageSize.toString()}
+                    onValueChange={newPageSize => table.setPageSize(parseInt(newPageSize))}
+                  />
+                  <Text className={styles.inlineFlexCenter}>records per page</Text>
+                </Flex>
+              </FooterWrapper>
+            </nav>
+          </Pagination>
+        )}
+      </Flex>
     </Flex>
   )
 }

--- a/components/tanstack-table.module.scss
+++ b/components/tanstack-table.module.scss
@@ -76,6 +76,7 @@
   padding: 0.5em;
   border-radius: 0.5em;
   margin-top: 0.5em;
+  margin-bottom: 0.5em;
 }
 
 .DropdownMenuCheckboxItem {

--- a/components/tanstack-table.module.scss
+++ b/components/tanstack-table.module.scss
@@ -68,3 +68,8 @@
     vertical-align: middle;
   }
 }
+
+.DropdownMenuContent {
+  background-color: white;
+  z-index: 1000;
+}

--- a/components/tanstack-table.module.scss
+++ b/components/tanstack-table.module.scss
@@ -70,14 +70,16 @@
 }
 
 .DropdownMenuContent {
-  background-color: var(--gray-1);
+  background-color: var(--color-panel-solid);
   color: var(--gray-12);
+  box-shadow: var(--shadow-5);
+  padding: 0.5em;
+  border-radius: 0.5em;
+  margin-top: 0.5em;
 }
 
 .DropdownMenuCheckboxItem {
-  font-size: 13px;
   line-height: 1;
-  border-radius: 3px;
   display: flex;
   align-items: center;
   height: 25px;

--- a/components/tanstack-table.module.scss
+++ b/components/tanstack-table.module.scss
@@ -70,6 +70,29 @@
 }
 
 .DropdownMenuContent {
-  background-color: white;
-  z-index: 1000;
+  background-color: var(--gray-1);
+  color: var(--gray-12);
+}
+
+.DropdownMenuCheckboxItem {
+  font-size: 13px;
+  line-height: 1;
+  border-radius: 3px;
+  display: flex;
+  align-items: center;
+  height: 25px;
+  padding: 0 5px;
+  position: relative;
+  padding-left: 25px;
+  user-select: none;
+  outline: none;
+}
+
+.DropdownMenuItemIndicator {
+  position: absolute;
+  left: 0;
+  width: 25px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }


### PR DESCRIPTION
- display selection of columns on tables but allow all possible columns to be displayed if desired
- allow multiple keyword search for array type columns (e.g searching for users with skills in react and python)

![image](https://github.com/user-attachments/assets/e277af31-565a-4b32-b52e-ff19a17a1eda)
*searching for multiple skills*

<img width="293" alt="Screenshot 2024-08-27 at 12 54 09" src="https://github.com/user-attachments/assets/e743118e-f976-4663-8180-2d49a6f93c14">
*dropdown for choosing which columns to display*