### PR TITLE
fix: display opportunity deadlines in client's timezone

### DIFF
--- a/app/events/[id]/FormattedClientDateTime.tsx
+++ b/app/events/[id]/FormattedClientDateTime.tsx
@@ -72,7 +72,7 @@ const FormattedClientDateTime = ({ dateStart, dateEnd }: { dateStart: Date; date
 
   if (!isClient) {
     return (
-      <Flex direction="row" gap="3">
+      <Flex direction="row" gap="3" align="center">
         <Spinner />
         Loading
       </Flex>

--- a/app/events/[id]/FormattedClientDateTime.tsx
+++ b/app/events/[id]/FormattedClientDateTime.tsx
@@ -29,7 +29,7 @@ import { BsCalendar } from "react-icons/bs"
 const formatEventDateTime = (dateStart: Date, dateEnd: Date | null) => {
   const formattedStart = (
     <b>
-      <time>{format(dateStart, "E, dd MMM kk:mm")}</time>
+      <time>{format(dateStart, "E, dd MMM HH:mm")}</time>
     </b>
   )
   const formattedEnd = dateEnd ? (
@@ -37,7 +37,7 @@ const formatEventDateTime = (dateStart: Date, dateEnd: Date | null) => {
       <>
         -
         <b>
-          <time>{format(dateEnd, "kk:mm")}</time>
+          <time>{format(dateEnd, "HH:mm")}</time>
         </b>
       </>
     ) : (
@@ -45,7 +45,7 @@ const formatEventDateTime = (dateStart: Date, dateEnd: Date | null) => {
         {" "}
         to{" "}
         <b>
-          <time>{format(dateEnd, "E, dd MMM kk:mm")}</time>
+          <time>{format(dateEnd, "E, dd MMM HH:mm")}</time>
         </b>
       </>
     )

--- a/app/opportunities/[id]/ClientDeadline.tsx
+++ b/app/opportunities/[id]/ClientDeadline.tsx
@@ -19,7 +19,7 @@ const ClientDeadline = ({ date }: { date: Date }) => {
       </Flex>
     )
   }
-  return <Text>{format(date, "dd/MM/yyyy kk:mm O")}</Text>
+  return <Text>{format(date, "dd/MM/yyyy HH:mm O")}</Text>
 }
 
 export default ClientDeadline

--- a/app/opportunities/[id]/ClientDeadline.tsx
+++ b/app/opportunities/[id]/ClientDeadline.tsx
@@ -19,7 +19,7 @@ const ClientDeadline = ({ date }: { date: Date }) => {
       </Flex>
     )
   }
-  return <Text>{format(date, "dd/MM/yyyy HH:mm O")}</Text>
+  return <Text>{format(date, "dd/MM/yyyy kk:mm O")}</Text>
 }
 
 export default ClientDeadline

--- a/app/opportunities/[id]/ClientDeadline.tsx
+++ b/app/opportunities/[id]/ClientDeadline.tsx
@@ -1,0 +1,25 @@
+"use client"
+
+import { Flex, Spinner, Text } from "@radix-ui/themes"
+import { format } from "date-fns"
+import React, { useEffect, useState } from "react"
+
+const ClientDeadline = ({ date }: { date: Date }) => {
+  const [isClient, setIsClient] = useState(false)
+
+  useEffect(() => {
+    setIsClient(true)
+  }, [])
+
+  if (!isClient) {
+    return (
+      <Flex direction="row" gap="3" align="center">
+        <Spinner />
+        Loading
+      </Flex>
+    )
+  }
+  return <Text>{format(date, "dd/MM/yyyy HH:mm O")}</Text>
+}
+
+export default ClientDeadline

--- a/app/opportunities/[id]/page.tsx
+++ b/app/opportunities/[id]/page.tsx
@@ -7,6 +7,7 @@ import { EditOpportunity } from "@/components/UpsertOpportunity"
 import RestrictedAreaCompany from "@/components/rbac/RestrictedAreaCompany"
 import prisma from "@/lib/db"
 
+import ClientDeadline from "./ClientDeadline"
 import styles from "./page.module.scss"
 
 import { Box, Button, Card, Flex, Grid, Heading, Inset, Text } from "@radix-ui/themes"
@@ -105,7 +106,7 @@ const OpportunityPage = async ({ params }: { params: { id: string } }) => {
 
               <BsClock />
               <Text>Deadline</Text>
-              <Text>{format(opportunity.deadline, "dd/MM/yyyy HH:mm")}</Text>
+              <ClientDeadline date={opportunity.deadline} />
 
               {opportunity.available ? (
                 <>

--- a/components/UpsertOpportunity.tsx
+++ b/components/UpsertOpportunity.tsx
@@ -5,8 +5,11 @@ import { Dropdown } from "@/components/Dropdown"
 import { PlusButton } from "@/components/buttons/PlusButton"
 import { FormInModal } from "@/components/forms/FormInModal"
 import { GenericFormModal } from "@/components/modals/GenericFormModal"
+import { TIMEZONE } from "@/lib/constants"
 import { createOpportunity, updateOpportunity } from "@/lib/crud/opportunities"
 import { FormPassBackState } from "@/lib/types"
+
+import { InfoCallout } from "./Callouts"
 
 import { Opportunity, OpportunityType } from "@prisma/client"
 import { Pencil1Icon } from "@radix-ui/react-icons"
@@ -82,6 +85,7 @@ const UpsertOpportunityForm = ({
         ></Dropdown>
         <input type="hidden" readOnly name="type" value={opportunityType} />
       </label>
+      <InfoCallout message={`The times correspond to the ${TIMEZONE} timezone.`} />
       <label>
         <Text as="div" size="2" mb="1" weight="bold">
           Application deadline*


### PR DESCRIPTION
- Display opportunity deadlines in client's timezone
- Add a callout to UpsertOpportunity to provide more information about timezone

![Screenshot 2024-08-28 at 13 17 10](https://github.com/user-attachments/assets/0c27d933-88e2-4786-aa53-999c8316b563)

![Screenshot 2024-08-28 at 13 17 24](https://github.com/user-attachments/assets/839ad25a-496d-4bec-8394-46c84fb6f30b)
