### PR TITLE
feat: file viewer

### DIFF
--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { getCompanyLink } from "@/app/companies/getCompanyLink"
 import { auth } from "@/auth"
 import { DeleteEvent } from "@/components/DeleteEvent"
+import { FileViewer } from "@/components/FileViewer"
 import Link from "@/components/Link"
 import MdViewer from "@/components/MdViewer"
 import { EditEvent } from "@/components/UpsertEvent"
@@ -16,7 +17,7 @@ import { format } from "date-fns"
 import Image from "next/image"
 import { notFound } from "next/navigation"
 import React from "react"
-import { BsBoxArrowUpRight, BsPinMap } from "react-icons/bs"
+import { BsBoxArrowUpRight, BsFileRichtext, BsPinMap } from "react-icons/bs"
 
 const EventPage = async ({ params }: { params: { id: string } }) => {
   const session = await auth()
@@ -89,6 +90,21 @@ const EventPage = async ({ params }: { params: { id: string } }) => {
       </Card>
 
       <Card className={styles.aboutCard}>
+        {event.attachment && (
+          <Flex gap="2" direction="column">
+            <Heading>Attachment</Heading>
+
+            <FileViewer fileUrl={`/api/uploads/${event.attachment}`} title={`${event.title} attachment`}>
+              <Flex align="center" gap="2" asChild width="fit-content">
+                <Link href="">
+                  <BsFileRichtext />
+                  View details
+                </Link>
+              </Flex>
+            </FileViewer>
+          </Flex>
+        )}
+
         <Flex gap="2" direction="column">
           <Heading>Date & Time</Heading>
 

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -76,7 +76,7 @@ const EventPage = async ({ params }: { params: { id: string } }) => {
                 <Heading>Sign Up</Heading>
 
                 <Button size="3" className={styles.signupButton} asChild>
-                  <Link href={event.link} target="_blank">
+                  <Link href={event.link} target="_blank" radixProps={{ underline: "none" }}>
                     Register for this event
                   </Link>
                 </Button>

--- a/app/students/[shortcode]/page.tsx
+++ b/app/students/[shortcode]/page.tsx
@@ -1,6 +1,7 @@
 import { auth } from "@/auth"
 import Chip from "@/components/Chip"
 import { EditStudent } from "@/components/EditStudent"
+import { FileViewer } from "@/components/FileViewer"
 import Link from "@/components/Link"
 import MdViewer from "@/components/MdViewer"
 import UserAvatar from "@/components/UserAvatar"
@@ -67,6 +68,8 @@ const StudentProfilePage = async ({ params }: { params: { shortcode: string } })
     notFound()
   }
 
+  const firstName = studentProfile.user.name?.split(",").reverse()[0].trim()
+
   return (
     <RestrictedArea allowedRoles={["STUDENT", "COMPANY"]}>
       <Card className={styles.container}>
@@ -102,12 +105,14 @@ const StudentProfilePage = async ({ params }: { params: { shortcode: string } })
                   session.user.role === "COMPANY" || session.user.id === studentProfile.userId
                 }
               >
-                <Flex align="center" gap="2" asChild>
-                  <Link href={`/api/uploads/${studentProfile.cv}`} target="_blank" underline="none">
-                    <BsFileEarmarkText title="download cv" color="var(--gray-12)" />
-                    <Text>{studentProfile.user.name?.split(",").reverse()[0].trim()}&apos;s CV</Text>
+                <FileViewer fileUrl={`/api/uploads/${studentProfile.cv}`} title={`${firstName}'s CV`}>
+                  <Link asChild href="">
+                    <Flex align="center" gap="2">
+                      <BsFileEarmarkText title="download cv" color="var(--gray-12)" />
+                      <Text>{firstName}&apos;s CV</Text>
+                    </Flex>
                   </Link>
-                </Flex>
+                </FileViewer>
               </RestrictedArea>
             )}
             <Flex align="center" gap="2">

--- a/app/students/[shortcode]/page.tsx
+++ b/app/students/[shortcode]/page.tsx
@@ -108,7 +108,7 @@ const StudentProfilePage = async ({ params }: { params: { shortcode: string } })
                 <FileViewer fileUrl={`/api/uploads/${studentProfile.cv}`} title={`${firstName}'s CV`}>
                   <Link asChild href="">
                     <Flex align="center" gap="2">
-                      <BsFileEarmarkText title="download cv" color="var(--gray-12)" />
+                      <BsFileEarmarkText title="view cv" color="var(--gray-12)" />
                       <Text>{firstName}&apos;s CV</Text>
                     </Flex>
                   </Link>

--- a/components/FileInput.tsx
+++ b/components/FileInput.tsx
@@ -1,6 +1,8 @@
-import { Button, Text } from "@radix-ui/themes"
+import { FileViewer } from "@/components/FileViewer"
+
+import { Button, Flex, Text } from "@radix-ui/themes"
 import { useState } from "react"
-import { BsCloudUploadFill } from "react-icons/bs"
+import { BsCloudUploadFill, BsSearch } from "react-icons/bs"
 
 /**
  * Form input which allows the user to upload a file.
@@ -16,23 +18,34 @@ const FileInput = ({ name, header, value }: { name: string; header: string; valu
       <Text as="div" size="2" weight="bold">
         {header}
       </Text>
-      <Button asChild>
-        <label>
-          <input
-            type="file"
-            hidden
-            name={name}
-            onChange={e => {
-              const file = e.target.files?.[0]
-              if (file) {
-                setFile(file.name)
-              }
-            }}
-          />
-          <BsCloudUploadFill size="1.2em" />
-          {file || "Upload file"}
-        </label>
-      </Button>
+      <Flex gap="2">
+        <Button asChild style={{ flexGrow: 1, cursor: "pointer" }}>
+          <label>
+            <input
+              type="file"
+              hidden
+              name={name}
+              onChange={e => {
+                const file = e.target.files?.[0]
+                if (file) {
+                  setFile(file.name)
+                }
+              }}
+            />
+
+            <BsCloudUploadFill size="1.2em" />
+            {file || "Upload file"}
+          </label>
+        </Button>
+        {file === value && ( // If a file is already uploaded, and hasn't been changed, show a view button
+          <FileViewer fileUrl={"/api/uploads/" + file} title={header}>
+            <Button variant="outline" style={{ flexGrow: 0, cursor: "pointer" }}>
+              <BsSearch />
+              View
+            </Button>
+          </FileViewer>
+        )}
+      </Flex>
     </>
   )
 }

--- a/components/FileViewer.tsx
+++ b/components/FileViewer.tsx
@@ -39,7 +39,7 @@ export const FileViewer = ({ fileUrl, title, children }: { fileUrl: string; titl
 
           <Flex className={styles.buttons} justify="end" gap="4">
             <Button asChild>
-              <Link href={fileUrl} target="_blank" download>
+              <Link href={fileUrl} target="_blank" download radixProps={{ underline: "none" }}>
                 <BsDownload />
                 Download
               </Link>

--- a/components/FileViewer.tsx
+++ b/components/FileViewer.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import Link from "@/components/Link"
+
+import styles from "./fileViewer.module.scss"
+
+import { Button, Dialog, Flex } from "@radix-ui/themes"
+import Image from "next/image"
+import React, { ReactNode, useState } from "react"
+import { BsDownload, BsXCircle } from "react-icons/bs"
+
+/**
+ * A modal to view a file.
+ * @param fileUrl The URL of the file to view.
+ * @param title The title of the file.
+ * @param children The trigger for the modal.
+ */
+export const FileViewer = ({ fileUrl, title, children }: { fileUrl: string; title: string; children: ReactNode }) => {
+  const [openState, setOpenState] = useState(false)
+
+  const isImage = fileUrl.match(/\.(jpeg|jpg|gif|png)$/)
+
+  const close = () => setOpenState(false)
+  return (
+    <Dialog.Root open={openState} onOpenChange={setOpenState} defaultOpen={false}>
+      <Dialog.Trigger>{children}</Dialog.Trigger>
+
+      <Dialog.Content className={styles.container} maxWidth="auto">
+        <Dialog.Title size="8" className={styles.title}>
+          {title}
+        </Dialog.Title>
+
+        <Flex direction="column" className={styles.content} gap="4">
+          {isImage ? (
+            <Image src={fileUrl} alt={title} className={styles.image} width={0} height={0} unoptimized />
+          ) : (
+            <iframe src={fileUrl} title={title} className={styles.iframe} />
+          )}
+
+          <Flex className={styles.buttons} justify="end" gap="4">
+            <Button asChild>
+              <Link href={fileUrl} target="_blank" download>
+                <BsDownload />
+                Download
+              </Link>
+            </Button>
+
+            <Button onClick={close} color="red">
+              <BsXCircle />
+              Close
+            </Button>
+          </Flex>
+        </Flex>
+      </Dialog.Content>
+    </Dialog.Root>
+  )
+}

--- a/components/fileViewer.module.scss
+++ b/components/fileViewer.module.scss
@@ -1,0 +1,30 @@
+.container {
+  max-height: calc(100vh - var(--space-6) - max(var(--space-6), 6vh));
+  max-width: min(80vw, 1000px);
+}
+
+.content {
+  height: 100%;
+}
+
+.iframe {
+  width: 100%;
+  aspect-ratio: 1 / sqrt(2); // A4 aspect ratio
+}
+
+.title {
+  text-align: center;
+}
+.buttons {
+  width: 100%;
+
+  button {
+    cursor: pointer;
+  }
+}
+
+.image {
+  width: auto;
+  height: 100%;
+  object-fit: contain;
+}


### PR DESCRIPTION
- Add a file viewer modal, used for:
  - Previewing uploaded files in forms
  - Viewing student CVs and event attachments

![image](https://github.com/user-attachments/assets/d49e3420-2f38-4248-8fdf-c7ab9655c9f1)
*The attachment section in an event*

![image](https://github.com/user-attachments/assets/8231b7c9-18d6-40e8-ba96-9e5982b942ab)
*The view button on file inputs which already have values*

![image](https://github.com/user-attachments/assets/05e5fc1e-a571-4801-9ad2-10174b1fb26a)
*The file viewer modal with a PDF (in Firefox)*

![image](https://github.com/user-attachments/assets/529e7bbe-c707-4016-813f-b047bba71518)
*The file viewer modal with an image*