### PR TITLE
feat: correctly redirect to callback URL on login

### DIFF
--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -13,19 +13,19 @@ import { BsBoxArrowRight } from "react-icons/bs"
 
 const ThemedLogo = dynamic(() => import("@/components/ThemedLogo"), { ssr: false })
 
-const LoginPage = async () => {
+const LoginPage = async ({ searchParams }: { searchParams?: { callbackUrl?: string } }) => {
   const signInEntraID = async () => {
     "use server"
     try {
       await signIn("microsoft-entra-id", {
-        redirectTo: "/",
+        redirectTo: searchParams?.callbackUrl ?? "/",
       })
     } catch (error) {
       // Signin can fail for a number of reasons, such as the user
       // not existing, or the user not having the correct role.
       // In some cases, you may want to redirect to a custom error
       if (error instanceof AuthError) {
-        return redirect(`/auth/errror?error=${error.type}`)
+        return redirect(`/auth/error?error=${error.type}`)
       }
 
       // Otherwise if a redirects happens NextJS can handle it

--- a/auth.config.ts
+++ b/auth.config.ts
@@ -4,7 +4,6 @@ import { getDepartment } from "./lib/graph"
 import { Prisma, Role } from "@prisma/client"
 import { DefaultSession, NextAuthConfig } from "next-auth"
 import MicrosoftEntraIDProfile from "next-auth/providers/microsoft-entra-id"
-import Nodemailer from "next-auth/providers/nodemailer"
 
 const ALLOWED_ADMINS = process.env.CPP_ALLOWED_ADMINS?.split(",") ?? []
 const ALLOWED_DEPARTMENTS = process.env.CPP_ALLOWED_DEPARTMENTS?.split(",") ?? ["Computing"]
@@ -141,7 +140,6 @@ export default {
     },
   },
 
-  // TODO: uncomment when we have a login page
   pages: {
     signIn: "/auth/login",
     verifyRequest: "/auth/login/partner/success",


### PR DESCRIPTION
- Redirect users to the URL in the `callbackUrl` param, which previously had no purpose