### PR TITLE
fix: volume size errors

### DIFF
--- a/components/forms/FormWithAction.tsx
+++ b/components/forms/FormWithAction.tsx
@@ -50,7 +50,7 @@ export function FormWithAction({
   const [isPending, startTransition] = useTransition()
   const wrappedAction = useCallback(
     (prevState: FormPassBackState, formData: FormData): Promise<FormPassBackState> => {
-      return new Promise(async (resolve, reject) => {
+      return new Promise(async (resolve, _reject) => {
         startTransition(async () => {
           try {
             const res = await action(prevState, formData)
@@ -58,8 +58,11 @@ export function FormWithAction({
               onSuccess?.(res)
             }
             resolve(res)
-          } catch (e) {
-            reject(e)
+          } catch (e: any) {
+            resolve({
+              status: "error",
+              message: `An unexpected error occurred: ${e.message}. This may be related to the nginx configuration. Please contact us if this error persists.`,
+            })
           }
         })
       })

--- a/components/forms/FormWithAction.tsx
+++ b/components/forms/FormWithAction.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { MAX_FILE_SIZE } from "@/lib/constants"
 import { FormPassBackState, ServerSideFormHandler } from "@/lib/types"
 
 import { ErrorCallout } from "../Callouts"
@@ -53,6 +54,22 @@ export function FormWithAction({
       return new Promise(async (resolve, _reject) => {
         startTransition(async () => {
           try {
+            // Check if the total size of the files is too large
+            let totalSize = 0
+            formData.forEach(value => {
+              if (value instanceof File) {
+                totalSize += value.size
+              }
+            })
+            if (totalSize >= MAX_FILE_SIZE) {
+              resolve({
+                status: "error",
+                message:
+                  "The total size of the files you are trying to upload is too large (total is over 1MB). Please try again with smaller files, or fewer files at once.",
+              })
+              return
+            }
+
             const res = await action(prevState, formData)
             if (res.status === "success") {
               onSuccess?.(res)

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,2 +1,5 @@
 // Timezone that is used to create events
 export const TIMEZONE = "Europe/London"
+
+// The maximum file size in bytes
+export const MAX_FILE_SIZE = 1_000_000 - 1

--- a/lib/files/saveFile.ts
+++ b/lib/files/saveFile.ts
@@ -1,10 +1,9 @@
+import { MAX_FILE_SIZE } from "@/lib/constants"
 import { FileCategory } from "@/lib/types"
 
 import { promises as fs } from "fs"
 import { join } from "path"
 import path from "path"
-
-const MAX_FILE_SIZE = 1000 * 1000 - 1 // Under 1MB
 
 // Must be the same as the allowed file types in the file viewer
 const allowedImageTypes = ["image/png", "image/jpeg", "image/gif", "image/svg+xml"]


### PR DESCRIPTION
- Impaas uses nginx, we can't control
- Nginx will sometimes block requests, for example, when the request body is too large (>1MB)
- This PR handles unexpected errors caused by nginx blocking these requests by:
  - Doing a client-side check for file size before running a form action
  - Appropriately handling undefined responses from server actions