### PR TITLE
fix: force dynamic on appropriate pages

### DIFF
--- a/app/companies/page.tsx
+++ b/app/companies/page.tsx
@@ -30,4 +30,5 @@ const OpportunitiesPage = async () => {
   )
 }
 
+export const dynamic = "force-dynamic"
 export default OpportunitiesPage

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -27,4 +27,5 @@ const EventsPage = async () => {
   )
 }
 
+export const dynamic = "force-dynamic"
 export default EventsPage

--- a/app/opportunities/page.tsx
+++ b/app/opportunities/page.tsx
@@ -26,4 +26,5 @@ const OpportunitiesPage = async () => {
   )
 }
 
+export const dynamic = "force-dynamic"
 export default OpportunitiesPage

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -143,5 +143,4 @@ const Home = async () => {
   )
 }
 
-export const dynamic = "force-dynamic"
 export default Home

--- a/app/students/page.tsx
+++ b/app/students/page.tsx
@@ -34,4 +34,5 @@ const StudentsPage = async () => {
   )
 }
 
+export const dynamic = "force-dynamic"
 export default StudentsPage


### PR DESCRIPTION
- Use "force-dynamic" on the companies, events, opportunities, and students pages
- This should reduce build errors related to prisma DB connections